### PR TITLE
Add a callback to the function signature. Add test Coverage.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var onHeaders = require('on-headers')
  * @api public
  */
 
-module.exports = function responseTime(options) {
+module.exports = function responseTime(options, callback) {
   if (typeof options === 'number') {
     // back-compat single number argument
     deprecate('number argument: use {digits: ' + JSON.stringify(options) + '} instead')
@@ -62,7 +62,9 @@ module.exports = function responseTime(options) {
       if (suffix) {
         val += 'ms'
       }
-
+      if(callback){
+        callback(val);
+      }
       this.setHeader(header, val)
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -104,8 +104,33 @@ describe('responseTime(options)', function () {
   })
 })
 
-function createServer(opts, fn) {
-  var _responseTime = responseTime(opts)
+describe('responseTime(options,callback)', function(done){
+  it('should accept a callback function', function (done){
+    var server = createServer({}, undefined , function(item){
+      console.log(item);
+    })
+    request(server)
+    .get('/')
+    .expect('X-Response-Time', /^[0-9\.]+ms$/, done)
+  })
+  it('should execute the callback for each request', function(done){
+    var test = undefined; 
+    var server = createServer({}, undefined, function(responseTime){
+      test = responseTime
+    })
+    request(server)
+    .get('/')
+    .expect(function(res){
+      if(!/^[0-9\.]+ms$/.test(test)){
+        throw new Error('callback did assign variable test correctly')
+      }
+    })
+    .end(done)
+  })
+})
+
+function createServer(opts, fn, callback) {
+  var _responseTime = responseTime(opts, callback)
   return http.createServer(function (req, res) {
     _responseTime(req, res, function (err) {
       setTimeout(function () {


### PR DESCRIPTION
Added an optional callback argument for responseTime. 
This callback will take one argument, the response time of the request.
All the old tests still pass. I added new tests to cover the new functionality.

Example Usage: 

```js
var express = require('express')
var responseTime = require('./response-time')

var app = express()

app.use(responseTime({digits: 5}, function(responseTime){
  console.log("Response time:", responseTime)
}))

app.get('/', function (req, res) {
  res.send('hello, world!')
})

app.listen(3000);

```

I added the callback as an argument, instead of a property in the options object, to keep in line with the pattern that node functions follow. 