### PR TITLE
Explicitly pass the handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function responseTime (options) {
       fn(req, res, time)
     })
 
-    next()
+    return next()
   }
 }
 


### PR DESCRIPTION
Since the codebase is not returning the `next` explicitly, when you have an async interface involving this library, the Promise exit early getting the implicit `undefined` until now returned.