### PR TITLE
chore: upgrade `depd` dependency to remove use of `eval`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage/
 node_modules/
 npm-debug.log
+package-lock.json

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 unreleased
 ==========
 
+  * deps: depd@~2.0.0
+    - Remove remove use of `eval`
   * deps: depd@~1.1.2
     - Remove unnecessary `Buffer` loading
     - perf: remove argument reassignment

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": "expressjs/response-time",
   "dependencies": {
-    "depd": "~1.1.2",
+    "depd": "^2.0.0",
     "on-headers": "~1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": "expressjs/response-time",
   "dependencies": {
-    "depd": "^2.0.0",
+    "depd": "~2.0.0",
     "on-headers": "~1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #22