### PR TITLE
ci: limit the scope to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: ci
 
 on:
-- pull_request
-- push
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
This will prevent issues with PRs for the new major (https://github.com/expressjs/response-time/issues/25) as happened with https://github.com/expressjs/response-time/pull/32